### PR TITLE
feat:메인페이지 카테고리 기능 추가

### DIFF
--- a/shoppingmall-front/src/css/Header.css
+++ b/shoppingmall-front/src/css/Header.css
@@ -197,3 +197,99 @@ ul {
   align-items: center;
   justify-content: center;
 }
+
+.header {
+    position: relative;  /* 자식인 메가 메뉴의 위치 기준점이 됨 */
+    z-index: 2000;      
+    background-color: #fff;
+}
+
+/* --- 메가 메뉴 스타일 --- */
+.mega-menu {
+    position: absolute;
+    top: 100%; /* 헤더 바로 아래 */
+    left: 0;
+    width: 100%;
+    background-color: #fff;
+    box-shadow: 0 10px 20px rgba(0,0,0,0.05);
+    overflow: hidden;
+    z-index: 2001; /* 다른 요소보다 위에 */
+    
+    /* 애니메이션 초기 상태 */
+    max-height: 0;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-10px);
+    transition: all 0.3s ease-in-out;
+    border-top: 1px solid #eee;
+}
+
+.mega-menu.active {
+    max-height: 400px; /* 충분한 높이 */
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+    padding-bottom: 20px; /* 하단 여백 */
+}
+
+.menu-inner {
+    display: flex;
+    justify-content: center;
+    gap: 100px; /* 카테고리 간 간격 */
+    padding: 50px 0;
+    max-width: 1280px;
+    margin: 0 auto;
+}
+
+.menu-column h3 {
+    font-size: 20px;
+    font-weight: 800;
+    color: #222;
+    margin-bottom: 25px;
+    border-bottom: 3px solid #222; /* 포인트 컬러 */
+    padding-bottom: 10px;
+    display: inline-block;
+    min-width: 140px;
+}
+
+.menu-column ul {
+    list-style: none;
+    padding: 0;
+}
+
+.menu-column ul li {
+    margin-bottom: 16px;
+}
+
+.menu-column ul li a {
+    text-decoration: none;
+    color: #666;
+    font-size: 16px;
+    transition: color 0.2s;
+    display: block;
+}
+
+.menu-column ul li a:hover {
+    color: #000;
+    font-weight: 700;
+    transform: translateX(5px);
+}
+
+/* --- 오버레이 (배경 흐림) --- */
+.menu-overlay {
+    position: fixed;
+    top: 0; /* 헤더 높이만큼 띄우려면 top 조정 필요할 수 있음 */
+    left: 0;
+    width: 100%;
+    height: 100vh;
+    background-color: rgba(0,0,0,0.3);
+    z-index: 1500;
+}
+
+/* btn_category 스타일 보정 (button 태그로 변경했으므로) */
+.btn_category {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+}


### PR DESCRIPTION
## 헤더(Header)에 동적 카테고리 메가 메뉴(Mega Menu) 기능 추가

**1. Header.js (로직 및 UI 구조 변경)**
- **카테고리 데이터 동적 로딩 (fetchCategories)**
  - axios를 통해 백엔드 API (/api/categories)에서 전체 카테고리 데이터를 가져옴
  - 계층 구조화: 가져온 데이터를 대분류(Parent)와 소분류(Child)로 분류하여 부모-자식 구조의 객체 배열(structuredMenu)로 변환

- **메뉴 토글 상태 관리 (isMenuOpen)**
  - 카테고리 버튼 클릭 시 메뉴를 열고 닫는 상태(isMenuOpen)를 추가했습니다.
  - 페이지 이동 시(location.pathname 변경 시) 메뉴가 자동으로 닫히도록 설정했습니다.

- **UI 렌더링 추가**
  - 메가 메뉴 영역: dynamicCategories를 순회하며 대분류 제목(h3)과 그 아래 소분류 리스트(ul > li)를 렌더링
  - 링크 연결: 각 카테고리 클릭 시 /product?categoryNo={id} 형태로 이동하여 해당 카테고리 상품을 조회하도록 변경
  - 오버레이: 메뉴가 열렸을 때 배경을 어둡게 하고, 배경 클릭 시 메뉴가 닫히는 menu-overlay를 추가
  - 버튼 태그 변경: 기존 <a> 태그였던 카테고리 버튼을 기능에 맞게 <button> 태그로 변경하고 onClick 이벤트를 연결

**2. Header.css (스타일링 추가)**
- **애니메이션 및 가시성 (.mega-menu)**
  - 메뉴가 부드럽게 내려오도록 transition, transform, opacity 속성을 사용하여 슬라이드 다운 애니메이션을 구현
  - 평소에는 감춰져 있다가 .active 클래스가 붙으면 max-height가 늘어나며 보임
- **레이아웃 (.menu-inner)**
  - Flexbox를 사용하여 대분류들이 가로로 정렬되도록 배치
  - 각 카테고리 제목(h3)과 리스트 아이템(li a)에 대한 폰트, 여백, 호버 효과(굵기 변경, 이동 등)를 적용

**배경 처리 (.menu-overlay)**
  - 메뉴가 열릴 때 화면 전체를 덮는 반투명 검은색 배경을 추가하여 포커스를 메뉴로 집중됨