### PR TITLE
fix:배포 환경 이미지 경로 도메인 수정 및 CORS 설정 추가

### DIFF
--- a/shoppingmall-back/src/main/java/com/shoppingmallcoco/project/config/WebMvcConfig.java
+++ b/shoppingmall-back/src/main/java/com/shoppingmallcoco/project/config/WebMvcConfig.java
@@ -2,6 +2,7 @@ package com.shoppingmallcoco.project.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -10,11 +11,26 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     @Value("${file.upload-dir}") // 프로퍼티 값 주입
     private String uploadDir;
+    
+    private final String[] ALLOWED_ORIGINS = {
+            "http://13.231.28.89:3000",
+            "http://13.231.28.89",
+            "http://13.231.28.89:18080" 
+        };
 
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         // file:/// 접두사를 붙여서 경로 설정
         registry.addResourceHandler("/images/**") // 웹 접근 경로
             .addResourceLocations("file:///" + uploadDir);
+    }
+    
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**") // 모든 경로에 대해
+                .allowedOrigins(ALLOWED_ORIGINS) // 허용할 프론트엔드 도메인
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS") // 허용할 HTTP 메서드
+                .allowedHeaders("*") // 모든 헤더 허용
+                .allowCredentials(true); // 인증 정보(쿠키, 토큰 등) 허용
     }
 }

--- a/shoppingmall-back/src/main/java/com/shoppingmallcoco/project/service/product/AdminProductService.java
+++ b/shoppingmall-back/src/main/java/com/shoppingmallcoco/project/service/product/AdminProductService.java
@@ -7,7 +7,6 @@ import com.shoppingmallcoco.project.service.review.IReviewService;
 
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,7 +43,7 @@ public class AdminProductService {
 	private String rootDir;
 	
 	// 도메인 상수 정의
-	private final String DOMAIN = "http://localhost:8080";
+	private final String DOMAIN = "http://13.231.28.89:18080";
 
 	// 상품 전용 업로드 폴더 경로
 	private String getProductUploadPath() {


### PR DESCRIPTION
## 배포 서버 환경 대응: CORS 설정 추가 및 이미지 도메인 주소 변경

### 변경 사항

### 1. CORS 설정 추가 (`WebMvcConfig.java`)
- 기존에 비어있던 `addCorsMappings` 설정을 구현.
- **허용 도메인:** 배포된 프론트/백엔드 서버(`13.231.28.89`)
- **허용 메서드:** GET, POST, PUT, DELETE, OPTIONS
- 모든 헤더 및 인증 정보(`allowCredentials`)를 허용하도록 설정하여 클라이언트와의 통신 오류를 해결

### 2. 이미지 도메인 상수 변경 (`AdminProductService.java`)
- 상품 이미지 경로 반환 시 사용되는 `DOMAIN` 상수를 변경
- **변경 전:** `http://localhost:8080`
- **변경 후:** `http://13.231.28.89:18080` (배포 서버 IP)
- 불필요한 `Autowired` import를 제거