### PR TITLE
fix:상품 이미지 업로드 시 리사이징 및 압축 로직 적용

### DIFF
--- a/shoppingmall-back/build.gradle
+++ b/shoppingmall-back/build.gradle
@@ -55,6 +55,9 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
+    
+    // 이미지 썸네일 및 리사이징 라이브러리 (Thumbnailator)
+    implementation 'net.coobird:thumbnailator:0.4.20'
 }
 
 tasks.named('test') {

--- a/shoppingmall-back/src/main/java/com/shoppingmallcoco/project/service/product/AdminProductService.java
+++ b/shoppingmall-back/src/main/java/com/shoppingmallcoco/project/service/product/AdminProductService.java
@@ -12,6 +12,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import net.coobird.thumbnailator.Thumbnails;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -225,7 +227,17 @@ public class AdminProductService {
 		String savedFileName = uuid + "_" + originalFilename;
 
 		File dest = new File(getProductUploadPath() + savedFileName);
-		file.transferTo(dest);
+		
+		// 원본 그대로 저장하지 않고, 리사이징 및 압축 후 저장
+		try {
+			Thumbnails.of(file.getInputStream())
+				.size(1000, 1000)   // 최대 너비/높이를 1000px로 제한 (비율 유지)
+				.outputQuality(0.8) // 이미지 품질을 80%로 설정 (용량 대폭 감소, 화질은 유지)
+				.toFile(dest);
+		} catch (IOException e) {
+			// 만약 변환 중 에러가 나면 원본이라도 저장하도록 처리
+			file.transferTo(dest);
+		}
 
 		// DB에 경로로 저장
 		ProductImageEntity image = new ProductImageEntity();


### PR DESCRIPTION
## fix:상품 이미지 업로드 용량 최적화 및 리사이징 적용

## 변경 내용
**1. 이미지 처리 라이브러리 추가**
- `build.gradle`: Java 이미지 썸네일 라이브러리인 `Thumbnailator` 의존성을 추가

**2. 이미지 저장 로직 개선 (`AdminProductService.java`)**
- 기존 `transferTo`를 사용하여 원본을 저장하던 방식 변경
- `Thumbnails`를 사용하여 업로드된 이미지를 다음과 같이 처리 후 저장
  - **Size**: 최대 1000px (비율 유지)
  - **Quality**: 0.8 (80%)
- 원본이 10MB 이하인 경우에만 업로드를 허용하는 유효성 검사 로직은 유지