### PR TITLE
fix:WebP 이미지 입출력 지원 라이브러리 추가

### DIFF
--- a/shoppingmall-back/build.gradle
+++ b/shoppingmall-back/build.gradle
@@ -58,6 +58,9 @@ dependencies {
     
     // 이미지 썸네일 및 리사이징 라이브러리 (Thumbnailator)
     implementation 'net.coobird:thumbnailator:0.4.20'
+    
+    // WebP 이미지 입출력 지원 라이브러리 (ImageIO Plugin)
+    implementation 'org.sejda.imageio:webp-imageio:0.1.6'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## WebP 이미지 처리를 위한 webp-imageio 의존성 추가

### 변경 사항
- `build.gradle`에 `org.sejda.imageio:webp-imageio:0.1.6` 의존성을 추가