### PR TITLE
fix:WebP 이미지 입출력 지원 라이브러리 수정

### DIFF
--- a/shoppingmall-back/build.gradle
+++ b/shoppingmall-back/build.gradle
@@ -59,8 +59,9 @@ dependencies {
     // 이미지 썸네일 및 리사이징 라이브러리 (Thumbnailator)
     implementation 'net.coobird:thumbnailator:0.4.20'
     
-    // WebP 이미지 입출력 지원 라이브러리 (ImageIO Plugin)
-    implementation 'org.sejda.imageio:webp-imageio:0.1.6'
+    // Java 이미지 처리 라이브러리 (TwelveMonkeys ImageIO)
+    implementation 'com.twelvemonkeys.imageio:imageio-webp:3.10.1' // WebP 지원
+    implementation 'com.twelvemonkeys.imageio:imageio-core:3.10.1' // 핵심 모듈
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## WebP 지원 라이브러리 변경 및 의존성 수정

### 목적
WebP 이미지 입출력 처리를 위한 라이브러리 의존성을 수정

### 변경 전/후
* **Before:** `org.sejda.imageio:webp-imageio` 사용
* **After:** `com.twelvemonkeys.imageio` (WebP 및 Core) 적용

### 수정 내용
기존 라이브러리 대신 Java 이미지 처리의 TwelveMonkeys 라이브러리를 적용하여 이미지 처리의 안정성 확보